### PR TITLE
Event systems

### DIFF
--- a/desktop/resources/assets.yaml
+++ b/desktop/resources/assets.yaml
@@ -194,6 +194,7 @@
     name: AreaTrigger
     components:
       - type: Transform
+      - type: EventHub
       - type: AreaTrigger
 
 # Block
@@ -260,6 +261,7 @@
   - asset: prefab
     name: RoachSoundPlayer
     components:
+      - type: EventHub
       - type: SoundPlayer
         params:
           audio-asset: SpaceRoachDeathSound

--- a/desktop/resources/platform.tmx
+++ b/desktop/resources/platform.tmx
@@ -20,7 +20,12 @@
   <object id="1" name="Player" type="Player" x="336.828" y="656.955">
    <ellipse/>
   </object>
-  <object id="13" name="trigger1" type="AreaTrigger" x="512" y="686.832" width="192" height="64"/>
+  <object id="13" name="trigger1" type="AreaTrigger" x="512" y="686.832" width="192" height="64">
+   <properties>
+    <property name="+on-enter" value="roachsound1:play"/>
+    <property name="+on-exit" value="roachsound1:play"/>
+   </properties>
+  </object>
   <object id="20" name="MusicPlayer" type="MusicPlayer" x="384" y="64" width="32" height="32" visible="0"/>
   <object id="23" name="roachsound1" type="RoachSoundPlayer" x="595" y="835" width="32" height="32"/>
  </objectgroup>

--- a/desktop/resources/platform.tmx
+++ b/desktop/resources/platform.tmx
@@ -17,12 +17,11 @@
   </data>
  </layer>
  <objectgroup name="Object Layer 1">
-  <object id="1" name="Player" x="336.828" y="656.955">
+  <object id="1" name="Player" type="Player" x="336.828" y="656.955">
    <ellipse/>
   </object>
-  <object id="13" name="AreaTrigger" x="512" y="686.832" width="192" height="64"/>
-  <object id="15" name="AreaTrigger" x="576" y="576" width="64" height="96"/>
-  <object id="20" name="MusicPlayer" x="384" y="64" width="32" height="32" visible="0"/>
-  <object id="23" name="RoachSoundPlayer" x="595" y="835" width="32" height="32"/>
+  <object id="13" name="trigger1" type="AreaTrigger" x="512" y="686.832" width="192" height="64"/>
+  <object id="20" name="MusicPlayer" type="MusicPlayer" x="384" y="64" width="32" height="32" visible="0"/>
+  <object id="23" name="roachsound1" type="RoachSoundPlayer" x="595" y="835" width="32" height="32"/>
  </objectgroup>
 </map>

--- a/desktop/src-common/ripple/audio.clj
+++ b/desktop/src-common/ripple/audio.clj
@@ -2,6 +2,7 @@
   (:import [com.badlogic.gdx Gdx])
   (:require [ripple.subsystem :as s]
             [ripple.components :as c]
+            [brute.entity :as e]
             [ripple.assets :as a]))
 
 (def instances (atom []))
@@ -37,14 +38,12 @@
             (.play))
           component))
 
-(c/defcomponent SoundPlayer
-  :fields [:audio-asset {:asset true}
-           :play-on-start {:default false}
-           :looping {:default true}
-           :pan {:default 0}
-           :volume {:default 1}]
-  :init (fn [component entity system params]
-          (assoc component :params params)))
+(defn play-sound
+  [system entity]
+  (let [sound-player (e/get-component system entity 'SoundPlayer)
+        {:keys [audio-asset looping volume pitch pan]} sound-player]
+    (.play audio-asset volume pitch pan))
+  system)
 
 (defn on-shutdown
   "Stop all sounds and release all resources"
@@ -54,6 +53,17 @@
     (.stop instance)
     (.dispose instance))
   (reset! instances []))
+
+(c/defcomponent SoundPlayer
+  :on-event [:play play-sound]
+  :fields [:audio-asset {:asset true}
+           :play-on-start {:default false}
+           :looping {:default true}
+           :pan {:default 0}
+           :pitch {:default 1}
+           :volume {:default 1}]
+  :init (fn [component entity system params]
+          (assoc component :params params)))
 
 (s/defsubsystem audio
   :on-show (fn [system]

--- a/desktop/src-common/ripple/components.clj
+++ b/desktop/src-common/ripple/components.clj
@@ -48,12 +48,14 @@
   [n & options]
   `(let [options# ~(apply hash-map options)
          fields# (apply hash-map (:fields options#))
+         on-event# (apply hash-map (:on-event options#))
          init-fn# (or (:init options#) (fn [c# _# _# _#] c#))]
      (intern *ns*  '~n (assoc options#
                               :create-component (fn [entity# system# params#]
                                                   (-> (#'ripple.components/init-component-fields system#
                                                                                                  params#
-                                                                                                 {:type '~n}
+                                                                                                 {:type '~n
+                                                                                                  :on-event on-event#}
                                                                                                  fields# )
                                                       (init-fn# entity# system# params#)))))))
 

--- a/desktop/src-common/ripple/core.clj
+++ b/desktop/src-common/ripple/core.clj
@@ -11,6 +11,7 @@
             [ripple.assets :as a]
             [ripple.subsystem :as subsystem]
             [ripple.prefab :as prefab]
+            [ripple.event :as event]
             [ripple.tiled-map :as tiled-map]
             [brute.entity :as e]
             [brute.system :as s]))
@@ -34,6 +35,7 @@
 
       (subsystem/register-subsystem a/assets)
       (subsystem/register-subsystem c/components)
+      (subsystem/register-subsystem event/events)
       (subsystem/register-subsystem rendering/rendering)
       (subsystem/register-subsystem physics/physics)
       (subsystem/register-subsystem prefab/prefabs)

--- a/desktop/src-common/ripple/event.clj
+++ b/desktop/src-common/ripple/event.clj
@@ -1,0 +1,52 @@
+(ns ripple.event
+  (:require [ripple.subsystem :as s]
+            [ripple.components :as c]
+            [brute.entity :as e]
+            [ripple.assets :as a]))
+
+(defn send-event
+  "Stores the given event in the event queue for the given entity"
+  [system entity event]
+  (let [event-hub (e/get-component system entity 'EventHub)]
+    (e/update-component system entity 'EventHub
+                        #(assoc % :event-queue (conj (:event-queue event-hub) event)))))
+
+(defn dispatch-event
+  [system entity event]
+
+  (let [components (e/get-all-components-on-entity system entity)
+        event-handlers (->> (map #(get-in % [:on-event event]) components)
+                            (filter #(not (nil? %))))]
+    (if (> (count event-handlers) 0)
+      (reduce (fn [system handler] (handler system entity))
+              system event-handlers)
+      system)))
+
+(defn dispatch-events
+  [system entity events]
+  (reduce (fn [system event] (dispatch-event system entity event))
+          system events))
+
+(defn- update-event-hub
+  [system entity]
+  (let [events (:event-queue (e/get-component system entity 'EventHub))]
+    (-> system
+        (dispatch-events entity events)
+        (e/update-component entity 'EventHub #(assoc % :event-queue [])))))
+
+(defn- update-event-hubs
+  [system]
+  (let [entities (e/get-all-entities-with-component system 'EventHub)]
+    (reduce update-event-hub system entities)))
+
+(c/defcomponent EventHub 
+  :fields [:tag {:default "untagged"}
+           :outputs {:default []}
+           :event-queue {:default []}])
+
+(s/defsubsystem events
+  :on-pre-render update-event-hubs
+  :on-show
+  (fn [system]
+    (c/register-component-def 'EventHub EventHub)
+    system))

--- a/desktop/src-common/ripple/repl.clj
+++ b/desktop/src-common/ripple/repl.clj
@@ -87,3 +87,7 @@
 
 (defn p-asset-defs []
   (aprint @ripple.assets/asset-defs))
+
+(defn get-components [system type]
+  (map #(e/get-component system % type)
+       (e/get-all-entities-with-component system type)))

--- a/desktop/src-common/ripple/tiled_map.clj
+++ b/desktop/src-common/ripple/tiled_map.clj
@@ -83,7 +83,7 @@
         y (+ (/ (.y rectangle) pixels-per-unit)
              (/ height 2))]
     (prefab/instantiate system
-                        (.getName map-object)
+                        (-> map-object (.getProperties) (.get "type"))
                         ;; TODO - more extendable way of instantiation params
                         {:transform {:position [x y]}
                          :areatrigger {:x x :y y :width width :height height}
@@ -97,7 +97,7 @@
         x (/ (.x ellipse) pixels-per-unit)
         y (/ (.y ellipse) pixels-per-unit)]
     (prefab/instantiate system
-                        (.getName map-object)
+                        (-> map-object (.getProperties) (.get "type"))
                         {:transform {:position [x y]}
                          :physicsbody {:x x :y y}})))
 


### PR DESCRIPTION
Allows basic data-driven event hookup through Tiled map object properties, e.g. setting "+on-enter" to "SomeObjectTag:play" will trigger the "play" event handler on entities tagged "SomeObjectTag" when "on-enter" happens.
